### PR TITLE
Upgrading boa-scan-builders to support amd64

### DIFF
--- a/agora/boa-scan-builder/docker-compose.yml
+++ b/agora/boa-scan-builder/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.3'
 services:
   boa-scan-builder:
-    platform: linux/arm64/v8
     container_name: boa-scan-builder
     image: bosagora/boa-scan-builder:v1.14.4
     ports:

--- a/agora/boa-scan-builder/scripts/build
+++ b/agora/boa-scan-builder/scripts/build
@@ -2,6 +2,8 @@
 
 cd /app
 
+mix local.hex --force
+
 mix do deps.get, local.rebar --force, deps.compile
 
 mix compile


### PR DESCRIPTION
docker buildx를 이용하여 멀티플랫폼용 docker 이미지를 제공
