### PR TITLE
Upgrade to include withdrawn rewards in the validator's total rewards

### DIFF
--- a/scripts/check/validator_balance.ts
+++ b/scripts/check/validator_balance.ts
@@ -8,17 +8,14 @@
 //
 // When running the script with `npx hardhat run <script>` you'll find the Hardhat
 
-import { Amount, GBOACoin } from "../utils/Amount";
-
-import { BigNumber } from "ethers";
-
 import axios from "axios";
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
 import URI from "urijs";
+import { BOACoin } from "../utils/Amount";
 
 // tslint:disable-next-line:no-var-requires
 const parsePrometheusTextFormat = require("parse-prometheus-text-format");
-// tslint:disable-next-line:no-var-requires
-const beautify = require("beautify");
 
 function delay(interval: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -26,8 +23,12 @@ function delay(interval: number): Promise<void> {
     });
 }
 async function main() {
+    const unit = BigNumber.from("1000000000");
+    const zero = BigNumber.from(0);
     let oldValue = BigNumber.from(0);
     const client = axios.create();
+    let oldEpoch = 0;
+    let newEpoch = 0;
     while (true) {
         try {
             const url = URI("http://localhost:8080/").filename("metrics").toString();
@@ -56,23 +57,39 @@ async function main() {
                     }
                 }
             }
+            // 초기 40개의 검증자중 인출주소가 등록된 32, 33번째 검증자는 인출주소로 리워드가 전송되기 때문에 리워드를 계산하기 위해 인출된 잔고를 확인한다.
+            const withdrawnRewards32 = await ethers.provider.getBalance("0xfF51d5A38b25AEc6Eb95a7De6835119372110317");
+            const withdrawnRewards33 = await ethers.provider.getBalance("0x28B248671efef5eAd82eD2AaEC88671DA09F6b64");
+
             const parsedBalances = parsePrometheusTextFormat(balances.join("\n"));
             const parsedValidators = parsePrometheusTextFormat(validators.join("\n"));
             const parsedSlots = parsePrometheusTextFormat(slots.join("\n"));
-            const validators_total_balance = BigNumber.from(Number(parsedBalances[0].metrics[0].value));
-            const validators_total_effective_balance = BigNumber.from(Number(parsedBalances[1].metrics[0].value));
-
-            if (!oldValue.eq(validators_total_balance)) {
+            const validators_total_balance = BigNumber.from(Number(parsedBalances[0].metrics[0].value))
+                .mul(unit)
+                .add(withdrawnRewards32)
+                .add(withdrawnRewards33);
+            const validators_total_effective_balance = BigNumber.from(Number(parsedBalances[1].metrics[0].value)).mul(
+                unit
+            );
+            const validators_total_reward = oldValue.eq(zero)
+                ? BigNumber.from(zero)
+                : validators_total_balance.sub(oldValue);
+            newEpoch = Math.floor(Number(parsedSlots[0].metrics[0].value) / 32);
+            if (newEpoch !== oldEpoch) {
                 console.log(
-                    `epoch : ${Math.floor(Number(parsedSlots[0].metrics[0].value) / 32)}, slot : ${Number(
-                        parsedSlots[0].metrics[0].value
-                    )}, validators : ${Number(parsedValidators[0].metrics[0].value)}, total : ${new GBOACoin(
-                        validators_total_balance
-                    ).toBOAString()}, effective : ${new GBOACoin(
+                    `Withdrawn Rewards (32): ${new BOACoin(withdrawnRewards32).toBOAString()}; (33) : ${new BOACoin(
+                        withdrawnRewards33
+                    ).toBOAString()}`
+                );
+                console.log(
+                    `epoch : ${newEpoch}, slot : ${Number(parsedSlots[0].metrics[0].value)}, validators : ${Number(
+                        parsedValidators[0].metrics[0].value
+                    )}, total : ${new BOACoin(validators_total_balance).toBOAString()}, effective : ${new BOACoin(
                         validators_total_effective_balance
-                    ).toBOAString()}, reward: ${new GBOACoin(validators_total_balance.sub(oldValue)).toBOAString()}`
+                    ).toBOAString()}, reward: ${new BOACoin(validators_total_reward).toBOAString()}`
                 );
                 oldValue = validators_total_balance;
+                oldEpoch = newEpoch;
             }
         } catch (e) {
             //


### PR DESCRIPTION
Capella 업그레이드 이후 인출된 리워드를 검증자의 전체 리워드에 포함하도록 수정하였다.
그리하여 리워드의 발행금액 예상금액과 동일한지 검사하도록 하였다